### PR TITLE
Code blocks text translated to English

### DIFF
--- a/syntax/code.md
+++ b/syntax/code.md
@@ -1,38 +1,39 @@
-# Les blocs de code
+# Code blocks
 
-Les blocs de codes pré-formatés sont utlisés pour écrire sur la programmation ou surligner un code source. Plus que de simple pragraphe, les lignes de code d'un bloc de code sont litterallement interprétées.
+Pre-formatted Code blocks are used to write programming or highlight source code. More than a simple paragraph, the lines of a Code block are literally interpreted.
 
-Voici un exemple :
-
-```
-Ceci est un bloc de code 
-```
-
-Afin de créer un bloc de code en Markdown, il suffit d'identer chaque ligne du bloc avec au moins 4 espaces ou une tabulation.
-
-Par exemple :
+Here's an example:
 
 ```
-Ceci est un paragraphe normal:
-
-    Ceci est un bloc de code. 
+This is a Code block
 ```
 
-Vous pouvez également créer un bloc de code separé avec:
+To create a Code block in Markdown, we must indent each line of it with at least 4 spaces or one tab.
+
+
+For example:
+
+```
+This is a normal paragraph:
+
+    This is a Code block. 
+```
+
+You can also create a separated Code block with:
 
     ```
 
-### Bloc de code en ligne
+### Inline Code block
 
-Les blocs de code en ligne peuvent être écrit en utilisant: `
+Inline Code blocks can be written using:`
 
-Par exemple:
+For example:
 
-    Ceci est `un bloc de code en ligne`
+    This is 'an inline code block'
 
-### La syntaxe de mise en avant 
+### Syntax highlighting
 
-Vous pouvez definir le langage utlisé pour mettre en évidence la syntaxe en ajoutant un nom sur un mot clé ouvrant. Exemple : 
+You can define the used language to highlight the syntax by adding a name to an open keyword. Example:
 
     ```js
     var a = {};


### PR DESCRIPTION
Pre-formatted code blocks are used to write programming or highlight source code. More than a simple paragraph, the lines of a Code block are literally interpreted.

Here's an example:

```
This is a Code block
```